### PR TITLE
Fix for GitHub save failing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
     "env": {
         "browser": true,
-        "es6": true
+        "es6": true,
+        "node": true
     },
     "settings": {
         "react": {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ git clone https://github.com/emilyskidsister/hacklily.git
 
 ### Running (without GitHub integration)
 
-Once you have installed the above dependencies, run
+Once you have installed the above dependencies, run:
 
 ```bash
 yarn install

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you specifically wish to test integration with GitHub, follow the steps in th
 First, create a GitHub organization by following the steps at https://github.com/organizations/new.
 Select the free plan.
 
-Next, create a new app at https://github.com/organizations/<your-new-repo-name>/settings/applications,
+Next, create a new app at https://github.com/organizations/your-new-repo-name/settings/applications,
 making note of the client ID and secret. This application will be used to allow users to log in.
 
 To run the frontend, in one shell run:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,29 @@ git clone https://github.com/emilyskidsister/hacklily.git
 Once you have installed the above dependencies, run
 
 ```bash
-make serve
+yarn install
+yarn build
+yarn start
+```
+
+Or if using npm:
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+In either case, to use the remote backend (instead of building your own local version), instead of running the `start` command, use:
+
+```bash
+yarn start:remote-backend
+```
+
+or:
+
+```bash
+npm run start:remote-backend
 ```
 
 ### Running (with GitHub integration)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm run build
 npm start
 ```
 
-In either case, to use the remote backend (instead of building your own local version), instead of running the `start` command, use:
+To use the remote backend (rather than building your own local renderer), **in place of the `start` command**, use:
 
 ```bash
 yarn start:remote-backend

--- a/server/renderer/Dockerfile
+++ b/server/renderer/Dockerfile
@@ -1,5 +1,5 @@
-FROM debian:sid-slim
-RUN apt-get update && apt-get install --no-install-recommends -y ruby curl bzip2 git locales gsfonts ghostscript fonts-dejavu-extra psmisc emacs-intl-fonts xfonts-intl-.* fonts-ipafont-mincho xfonts-bolkhov-75dpi xfonts-cronyx-100dpi xfonts-cronyx-75dpi patch python2 python3 && \
+FROM --platform=linux/amd64 debian:sid-slim
+RUN apt-get update && apt-get install --no-install-recommends -y adduser ruby curl bzip2 git locales gsfonts ghostscript fonts-dejavu-extra psmisc emacs-intl-fonts xfonts-intl-.* fonts-ipafont-mincho xfonts-bolkhov-75dpi xfonts-cronyx-100dpi xfonts-cronyx-75dpi patch python3 && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
     curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > /usr/local/bin/jq && \
     chmod +x /usr/local/bin/jq && echo 42 | jq .
@@ -17,9 +17,9 @@ RUN adduser --disabled-password --gecos '' r && \
     cd ~r/.lyp && \
     patch -p0 < /tmp/no_lyp_check_update.patch && \
     rm /tmp/no_lyp_check_update.patch && \
-    su r -c "source ~/.profile; lyp install lilypond@2.22.1 lys;" && \
-    rm /home/r/.lyp/lilyponds/2.22.1/etc/relocate/gs.reloc && \
-    rm /home/r/.lyp/lilyponds/2.22.1/bin/gs && \
+    su r -c "source ~/.profile; lyp install lilypond@2.24.1 lys;" && \
+    rm /home/r/.lyp/lilyponds/2.24.1/etc/relocate/gs.reloc && \
+    rm /home/r/.lyp/lilyponds/2.24.1/bin/gs && \
     chown r -R /tmp/* && \
     chown nobody -R /home/r/.lyp/*
 RUN apt-get remove -y curl patch && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/server/renderer/Dockerfile
+++ b/server/renderer/Dockerfile
@@ -17,9 +17,9 @@ RUN adduser --disabled-password --gecos '' r && \
     cd ~r/.lyp && \
     patch -p0 < /tmp/no_lyp_check_update.patch && \
     rm /tmp/no_lyp_check_update.patch && \
-    su r -c "source ~/.profile; lyp install lilypond@2.24.1 lys;" && \
-    rm /home/r/.lyp/lilyponds/2.24.1/etc/relocate/gs.reloc && \
-    rm /home/r/.lyp/lilyponds/2.24.1/bin/gs && \
+    su r -c "source ~/.profile; lyp install lilypond@2.23.6 lys;" && \
+    rm /home/r/.lyp/lilyponds/2.23.6/etc/relocate/gs.reloc && \
+    rm /home/r/.lyp/lilyponds/2.23.6/bin/gs && \
     chown r -R /tmp/* && \
     chown nobody -R /home/r/.lyp/*
 RUN apt-get remove -y curl patch && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/server/renderer/Dockerfile
+++ b/server/renderer/Dockerfile
@@ -17,9 +17,9 @@ RUN adduser --disabled-password --gecos '' r && \
     cd ~r/.lyp && \
     patch -p0 < /tmp/no_lyp_check_update.patch && \
     rm /tmp/no_lyp_check_update.patch && \
-    su r -c "source ~/.profile; lyp install lilypond@2.23.6 lys;" && \
-    rm /home/r/.lyp/lilyponds/2.23.6/etc/relocate/gs.reloc && \
-    rm /home/r/.lyp/lilyponds/2.23.6/bin/gs && \
+    su r -c "source ~/.profile; lyp install lilypond@2.22.1 lys;" && \
+    rm /home/r/.lyp/lilyponds/2.22.1/etc/relocate/gs.reloc && \
+    rm /home/r/.lyp/lilyponds/2.22.1/bin/gs && \
     chown r -R /tmp/* && \
     chown nobody -R /home/r/.lyp/*
 RUN apt-get remove -y curl patch && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,9 @@ module.exports = {
   plugins: [
     new CopyPlugin({ patterns: [path.resolve(__dirname, "static")] }),
     new MonacoWebpackPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': JSON.stringify(process.env)
+    }),
     new webpack.EnvironmentPlugin([
       "REACT_APP_GITHUB_CLIENT_ID",
       "REACT_APP_BACKEND_WS_URL",


### PR DESCRIPTION
resolves jocelyn-stericker/hacklily#55, resolves jocelyn-stericker/hacklily#33

Saving to GitHub was failing due to process.env not being available on the client side. Adding a few lines to the webpack.config.js fixes this.

Also, I updated the README.md as the makefile doesn't exist, so the `make serve` command is outdated? I updated the readme with the commands that (I think) should be run instead. I should note that I was getting an error with `yarn build` but not with `npm run build`. The yarn error had something to do with the enhanced-resolve npm plugin and the normalize.css file in src. 

Love your work on this, btw. Really nice and useful.